### PR TITLE
[AccessLint] Fixing Accessibility Issues

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -40,6 +40,7 @@
             </div>
             <div id="output"></div>
         </div>
+        
     <script>
         function loadDoc() {
             var xhttp = new XMLHttpRequest();


### PR DESCRIPTION
Looks like there's a label missing for this input. That makes it hard for people using screen readers or voice control to use the input. If you don't want a visual label, try an `aria-label` attribute.